### PR TITLE
Works!

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,9 @@ indent "Create profile.d script"
 # puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
 indent "Save LD_LIBRARY_PATH"
-`mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
+`ls -l #{ENV_DIR}`
+`cat #{ENV_DIR}/LD_LIBRARY_PATH`
+# `mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value')) { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -52,6 +52,6 @@ indent "Create profile.d script"
 # puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
 indent "Save LD_LIBRARY_PATH"
-open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value') { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
+open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value')) { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ ENV_DIR=ARGV[2]
 
 puts "-----> Found an .oracle.yml"
 
-ORACLE_CONFIG = YAML.load_file('.oracle.yml')
+ORACLE_CONFIG = YAML.load_file("#{BUILD_DIR}/.oracle.yml")
 ORACLE_INSTANT_CLIENT_DIR="vendor/oracle_instantclient"
 ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
 ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last

--- a/bin/compile
+++ b/bin/compile
@@ -52,8 +52,10 @@ indent "Create profile.d script"
 # puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
 indent "Save LD_LIBRARY_PATH"
-`ls -l #{ENV_DIR}`
-`cat #{ENV_DIR}/LD_LIBRARY_PATH`
+env_dir_contents = `ls -l #{ENV_DIR}`
+puts env_dir_contents
+puts `cat #{ENV_DIR}/LD_LIBRARY_PATH`
+
 # `mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value')) { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ puts "-----> Found an .oracle.yml"
 
 ORACLE_CONFIG = YAML.load_file("#{BUILD_DIR}/.oracle.yml")
 ORACLE_INSTANT_CLIENT_DIR="vendor/oracle_instantclient"
-ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
+ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/ro5rfqwgtjdo75b/oracle-instantclient-full-12.1-linux.x64.tar.gz"
 ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last
 
 indent "Making directory #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
@@ -57,6 +57,7 @@ open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
   f.puts "export LD_LIBRARY_PATH=#{ORACLE_HOME}:$LD_LIBRARY_PATH"
   f.puts "export PATH=#{ORACLE_HOME}:$PATH"
   f.puts "export TNS_ADMIN=#{ORACLE_HOME}/network/admin"
+  f.puts "alias ls='ls --color'"
 end
 
 indent "Save build LD_LIBRARY_PATH to ENV_DIR"
@@ -66,7 +67,7 @@ existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIB
 
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
   value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
-  value += ":#{existing_ld_library_path}"  if existing_ld_library_path
+  value += ":#{existing_ld_library_path}"  if existing_ld_library_path.andand.length > 0
   f.puts value
 end
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,51 +2,72 @@
 
 require 'tempfile'
 require 'fileutils'
+# require 'yaml'
 
 $stdout.sync = true
 
-def indent msg
+def indent(msg)
   puts "       #{msg}"
 end
 
 BUILD_DIR=ARGV[0]
-CACHE_DIR=ARGV[1]
 ENV_DIR=ARGV[2]
 
-puts "-----> Found an .oracle.ini"
+puts "-----> Found an .oracle.yml"
 
-ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"
+# ORACLE_CONFIG = YAML.load_file('.oracle.yml')
+# ORACLE_INSTANT_CLIENT_DIR="vendor/oracle_instantclient"
+# ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
+# ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last
 
-ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
-ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last
+# indent "Making directory #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
+# `mkdir -p #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}`
 
-indent "Making directory #{ORACLE_INSTANT_CLIENT_DIR}"
-`mkdir -p #{ORACLE_INSTANT_CLIENT_DIR}`
+# indent "Downloading and extracting #{ORACLE_INSTANT_CLIENT_FILENAME}"
+# result = `curl #{ORACLE_INSTANT_CLIENT_URL} -L -s -o - | tar -xvz -C #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR} -f - `
 
-indent "Downloading and extracting #{ORACLE_INSTANT_CLIENT_FILENAME}"
-result = `curl #{ORACLE_INSTANT_CLIENT_URL} -L -s -o - | tar -xvz -C #{ORACLE_INSTANT_CLIENT_DIR} -f - `
+# unless $?.success?
+#   indent "Failure while downloading Oracle instant client archive: #{$?}"
+#   exit 1
+# end
 
-unless $?.success?
-  indent "Failure while downloading Oracle instant client archive: #{$?}"
-  exit 1
-end
+# indent "Successfully extracted #{ORACLE_INSTANT_CLIENT_FILENAME}"
 
-indent "Successfully extracted #{ORACLE_INSTANT_CLIENT_FILENAME}"
+# ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/admin"
+# `mkdir -p #{ORACLE_NETWORK_ADMIN_DIR}`
 
-indent "Create profile.d script"
-`mkdir -p #{BUILD_DIR}/.profile.d`
+# TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
+# if File.exists?(TNSNAMES_FILENAME)
+#   indent "Symlinking #{TNSNAMES_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
+#   `ln -sf #{TNSNAMES_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
+# end
 
-open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
-   f.puts "export LD_LIBRARY_PATH=/app/vendor/oracle_instantclient:LD_LIBRARY_PATH"
-end
+# SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
+# if File.exists?(SQLNET_FILENAME)
+#   indent "Symlinking #{SQLNET_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
+#   `ln -sf #{SQLNET_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
+# end
 
-indent "Save LD_LIBRARY_PATH to ENV_DIR"
+# indent "Create profile.d script"
+# `mkdir -p #{BUILD_DIR}/.profile.d`
 
-existing_ld_library_path = `cat #{ENV_DIR}/LD_LIBRARY_PATH`
-open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
-  value = ORACLE_INSTANT_CLIENT_DIR
-  value += ":#{existing_ld_library_path}"  if existing_ld_library_path
-  f.puts value
-end
+# open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
+#   ORACLE_HOME = "/app/#{ORACLE_INSTANT_CLIENT_DIR}"
+#   f.puts "export ORACLE_HOME=#{ORACLE_HOME}"
+#   f.puts "export LD_LIBRARY_PATH=#{ORACLE_HOME}:$LD_LIBRARY_PATH"
+#   f.puts "export PATH=#{ORACLE_HOME}:$PATH"
+#   f.puts "export TNS_ADMIN=#{ORACLE_HOME}/network/admin"
+# end
+
+# indent "Save build LD_LIBRARY_PATH to ENV_DIR"
+
+# LD_LIBRARY_PATH_FILE = File.join(ENV_DIR, 'LD_LIBRARY_PATH')
+# existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIBRARY_PATH_FILE)
+
+# open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
+#   value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
+#   value += ":#{existing_ld_library_path}"  if existing_ld_library_path
+#   f.puts value
+# end
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ indent "Create profile.d script"
 # open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
 #   f.puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # end
-# puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
+puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
+`export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -15,59 +15,59 @@ ENV_DIR=ARGV[2]
 
 puts "-----> Found an .oracle.yml"
 
-# ORACLE_CONFIG = YAML.load_file('.oracle.yml')
-# ORACLE_INSTANT_CLIENT_DIR="vendor/oracle_instantclient"
-# ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
-# ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last
+ORACLE_CONFIG = YAML.load_file('.oracle.yml')
+ORACLE_INSTANT_CLIENT_DIR="vendor/oracle_instantclient"
+ORACLE_INSTANT_CLIENT_URL="https://www.dropbox.com/s/eadlfff7w9bjo44/instantclient-full-linux.x64-12.1.0.tar.gz"
+ORACLE_INSTANT_CLIENT_FILENAME=ORACLE_INSTANT_CLIENT_URL.split(/\//).last
 
-# indent "Making directory #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
-# `mkdir -p #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}`
+indent "Making directory #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
+`mkdir -p #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}`
 
-# indent "Downloading and extracting #{ORACLE_INSTANT_CLIENT_FILENAME}"
-# result = `curl #{ORACLE_INSTANT_CLIENT_URL} -L -s -o - | tar -xvz -C #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR} -f - `
+indent "Downloading and extracting #{ORACLE_INSTANT_CLIENT_FILENAME}"
+result = `curl #{ORACLE_INSTANT_CLIENT_URL} -L -s -o - | tar -xvz -C #{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR} -f - `
 
-# unless $?.success?
-#   indent "Failure while downloading Oracle instant client archive: #{$?}"
-#   exit 1
-# end
+unless $?.success?
+  indent "Failure while downloading Oracle instant client archive: #{$?}"
+  exit 1
+end
 
-# indent "Successfully extracted #{ORACLE_INSTANT_CLIENT_FILENAME}"
+indent "Successfully extracted #{ORACLE_INSTANT_CLIENT_FILENAME}"
 
-# ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/admin"
-# `mkdir -p #{ORACLE_NETWORK_ADMIN_DIR}`
+ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/admin"
+`mkdir -p #{ORACLE_NETWORK_ADMIN_DIR}`
 
-# TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
-# if File.exists?(TNSNAMES_FILENAME)
-#   indent "Symlinking #{TNSNAMES_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
-#   `ln -sf #{TNSNAMES_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
-# end
+TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
+if File.exists?(TNSNAMES_FILENAME)
+  indent "Symlinking #{TNSNAMES_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
+  `ln -sf #{TNSNAMES_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
+end
 
-# SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
-# if File.exists?(SQLNET_FILENAME)
-#   indent "Symlinking #{SQLNET_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
-#   `ln -sf #{SQLNET_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
-# end
+SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
+if File.exists?(SQLNET_FILENAME)
+  indent "Symlinking #{SQLNET_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
+  `ln -sf #{SQLNET_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
+end
 
-# indent "Create profile.d script"
-# `mkdir -p #{BUILD_DIR}/.profile.d`
+indent "Create profile.d script"
+`mkdir -p #{BUILD_DIR}/.profile.d`
 
-# open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
-#   ORACLE_HOME = "/app/#{ORACLE_INSTANT_CLIENT_DIR}"
-#   f.puts "export ORACLE_HOME=#{ORACLE_HOME}"
-#   f.puts "export LD_LIBRARY_PATH=#{ORACLE_HOME}:$LD_LIBRARY_PATH"
-#   f.puts "export PATH=#{ORACLE_HOME}:$PATH"
-#   f.puts "export TNS_ADMIN=#{ORACLE_HOME}/network/admin"
-# end
+open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
+  ORACLE_HOME = "/app/#{ORACLE_INSTANT_CLIENT_DIR}"
+  f.puts "export ORACLE_HOME=#{ORACLE_HOME}"
+  f.puts "export LD_LIBRARY_PATH=#{ORACLE_HOME}:$LD_LIBRARY_PATH"
+  f.puts "export PATH=#{ORACLE_HOME}:$PATH"
+  f.puts "export TNS_ADMIN=#{ORACLE_HOME}/network/admin"
+end
 
-# indent "Save build LD_LIBRARY_PATH to ENV_DIR"
+indent "Save build LD_LIBRARY_PATH to ENV_DIR"
 
-# LD_LIBRARY_PATH_FILE = File.join(ENV_DIR, 'LD_LIBRARY_PATH')
-# existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIBRARY_PATH_FILE)
+LD_LIBRARY_PATH_FILE = File.join(ENV_DIR, 'LD_LIBRARY_PATH')
+existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIBRARY_PATH_FILE)
 
-# open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
-#   value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
-#   value += ":#{existing_ld_library_path}"  if existing_ld_library_path
-#   f.puts value
-# end
+open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
+  value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
+  value += ":#{existing_ld_library_path}"  if existing_ld_library_path
+  f.puts value
+end
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,6 @@ open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
   f.puts "export LD_LIBRARY_PATH=#{ORACLE_HOME}:$LD_LIBRARY_PATH"
   f.puts "export PATH=#{ORACLE_HOME}:$PATH"
   f.puts "export TNS_ADMIN=#{ORACLE_HOME}/network/admin"
-  f.puts "alias ls='ls --color'"
 end
 
 indent "Save build LD_LIBRARY_PATH to ENV_DIR"
@@ -67,7 +66,7 @@ existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIB
 
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
   value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
-  value += ":#{existing_ld_library_path}"  if existing_ld_library_path && existing_ld_library_path.length > 0
+  value += ":#{existing_ld_library_path}"  if existing_ld_library_path && existing_ld_library_path.trim.length > 0
   f.puts value
 end
 

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,9 @@ indent "Create profile.d script"
 # open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
 #   f.puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # end
-puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
-`export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
+# puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
+# `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
+indent "Save LD_LIBRARY_PATH"
+open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value') { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -37,15 +37,15 @@ ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/ad
 `mkdir -p #{ORACLE_NETWORK_ADMIN_DIR}`
 
 TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
-if File.exists?(TNSNAMES_FILENAME)
-  indent "Symlinking #{TNSNAMES_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
-  `ln -sf #{TNSNAMES_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
+if File.exists?(File.join(BUILD_DIR,TNSNAMES_FILENAME))
+  indent "Symlinking #{TNSNAMES_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
+  `ln -sf #{File.join(BUILD_DIR,TNSNAMES_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
 end
 
 SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
-if File.exists?(SQLNET_FILENAME)
-  indent "Symlinking #{SQLNET_FILENAME} #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
-  `ln -sf #{SQLNET_FILENAME} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
+if File.exists?(File.join(BUILD_DIR,SQLNET_FILENAME))
+  indent "Symlinking #{SQLNET_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
+  `ln -sf #{File.join(BUILD_DIR,SQLNET_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
 end
 
 indent "Create profile.d script"

--- a/bin/compile
+++ b/bin/compile
@@ -19,6 +19,7 @@ indent "ENV_DIR=#{ENV_DIR.inspect}"
 
 Dir.foreach(ENV_DIR) { |x| indent x }
 
+
 puts "-----> Found a .oracle.ini"
 
 ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"

--- a/bin/compile
+++ b/bin/compile
@@ -38,14 +38,14 @@ ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/ad
 
 TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
 if File.exists?(File.join(BUILD_DIR,TNSNAMES_FILENAME))
-  indent "Copying #{TNSNAMES_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
-  `cp #{File.join(BUILD_DIR,TNSNAMES_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
+  indent "Symlinking #{TNSNAMES_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
+  `ln -sf #{File.join('/app',TNSNAMES_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
 end
 
 SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
 if File.exists?(File.join(BUILD_DIR,SQLNET_FILENAME))
-  indent "Copying #{SQLNET_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
-  `cp #{File.join(BUILD_DIR,SQLNET_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
+  indent "Symlinking #{SQLNET_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
+  `ln -sf #{File.join('/app',SQLNET_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
 end
 
 indent "Create profile.d script"

--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,10 @@ BUILD_DIR=ARGV[0]
 CACHE_DIR=ARGV[1]
 ENV_DIR=ARGV[2]
 
+indent "BUILD_DIR=#{BUILD_DIR}"
+indent "CACHE_DIR=#{CACHE_DIR}"
+indent "ENV_DIR=#{ENV_DIR.inspect}"
+
 puts "-----> Found a .oracle.ini"
 
 ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"

--- a/bin/compile
+++ b/bin/compile
@@ -17,8 +17,8 @@ indent "BUILD_DIR=#{BUILD_DIR}"
 indent "CACHE_DIR=#{CACHE_DIR}"
 indent "ENV_DIR=#{ENV_DIR.inspect}"
 
+indent "Contents of ENV_DIR are:"
 Dir.foreach(ENV_DIR) { |x| indent x }
-
 
 puts "-----> Found a .oracle.ini"
 

--- a/bin/compile
+++ b/bin/compile
@@ -9,18 +9,7 @@ def indent msg
   puts "       #{msg}"
 end
 
-BUILD_DIR=ARGV[0]
-CACHE_DIR=ARGV[1]
-ENV_DIR=ARGV[2]
-
-indent "BUILD_DIR=#{BUILD_DIR}"
-indent "CACHE_DIR=#{CACHE_DIR}"
-indent "ENV_DIR=#{ENV_DIR.inspect}"
-
-indent "Contents of ENV_DIR are:"
-Dir.foreach(ENV_DIR) { |x| indent x }
-
-puts "-----> Found a .oracle.ini"
+puts "-----> Found an .oracle.ini"
 
 ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"
 
@@ -38,26 +27,22 @@ unless $?.success?
   exit 1
 end
 
-result = `ls -l #{ORACLE_INSTANT_CLIENT_DIR}`
-indent result
-
 indent "Successfully extracted #{ORACLE_INSTANT_CLIENT_FILENAME}"
 
 indent "Create profile.d script"
 `mkdir -p #{BUILD_DIR}/.profile.d`
 
-# open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
-#   f.puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
-# end
-# puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
-# `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
-indent "Save LD_LIBRARY_PATH"
-env_dir_contents = `ls -l #{ENV_DIR}`
-puts env_dir_contents
-puts `cat #{ENV_DIR}/LD_LIBRARY_PATH`
-puts `file #{ENV_DIR}/LD_LIBRARY_PATH`
+open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
+   f.puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
+end
 
-# `mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
-open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
+indent "Save LD_LIBRARY_PATH to ENV_DIR"
+
+existing_ld_library_path = `cat #{ENV_DIR}/LD_LIBRARY_PATH`
+open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
+  value = ORACLE_INSTANT_CLIENT_DIR
+  value += ":#{existing_ld_library_path}"  if existing_ld_library_path
+  f.puts value
+end
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -52,6 +52,7 @@ indent "Create profile.d script"
 # puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
 # `export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH`
 indent "Save LD_LIBRARY_PATH"
+`mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value')) { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,10 @@ def indent msg
   puts "       #{msg}"
 end
 
+BUILD_DIR=ARGV[0]
+CACHE_DIR=ARGV[1]
+ENV_DIR=ARGV[2]
+
 puts "-----> Found an .oracle.ini"
 
 ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"

--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,8 @@ indent "BUILD_DIR=#{BUILD_DIR}"
 indent "CACHE_DIR=#{CACHE_DIR}"
 indent "ENV_DIR=#{ENV_DIR.inspect}"
 
+Dir.foreach(ENV_DIR) { |x| indent x }
+
 puts "-----> Found a .oracle.ini"
 
 ORACLE_INSTANT_CLIENT_DIR="#{ARGV[0]}/vendor/oracle_instantclient"

--- a/bin/compile
+++ b/bin/compile
@@ -38,14 +38,14 @@ ORACLE_NETWORK_ADMIN_DIR = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}/network/ad
 
 TNSNAMES_FILENAME = ORACLE_CONFIG['tnsnames.ora']
 if File.exists?(File.join(BUILD_DIR,TNSNAMES_FILENAME))
-  indent "Symlinking #{TNSNAMES_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
-  `ln -sf #{File.join(BUILD_DIR,TNSNAMES_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
+  indent "Copying #{TNSNAMES_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/tnsnames.ora"
+  `cp #{File.join(BUILD_DIR,TNSNAMES_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/tnsnames.ora`
 end
 
 SQLNET_FILENAME = ORACLE_CONFIG['sqlnet.ora']
 if File.exists?(File.join(BUILD_DIR,SQLNET_FILENAME))
-  indent "Symlinking #{SQLNET_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
-  `ln -sf #{File.join(BUILD_DIR,SQLNET_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
+  indent "Copying #{SQLNET_FILENAME} to #{ORACLE_INSTANT_CLIENT_DIR}/network/admin/sqlnet.ora"
+  `cp #{File.join(BUILD_DIR,SQLNET_FILENAME)} #{ORACLE_NETWORK_ADMIN_DIR}/sqlnet.ora`
 end
 
 indent "Create profile.d script"

--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,7 @@ existing_ld_library_path = `cat #{LD_LIBRARY_PATH_FILE}`  if File.exists?(LD_LIB
 
 open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') do |f|
   value = "#{BUILD_DIR}/#{ORACLE_INSTANT_CLIENT_DIR}"
-  value += ":#{existing_ld_library_path}"  if existing_ld_library_path.andand.length > 0
+  value += ":#{existing_ld_library_path}"  if existing_ld_library_path && existing_ld_library_path.length > 0
   f.puts value
 end
 

--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,7 @@
 
 require 'tempfile'
 require 'fileutils'
-# require 'yaml'
+require 'yaml'
 
 $stdout.sync = true
 

--- a/bin/compile
+++ b/bin/compile
@@ -55,8 +55,9 @@ indent "Save LD_LIBRARY_PATH"
 env_dir_contents = `ls -l #{ENV_DIR}`
 puts env_dir_contents
 puts `cat #{ENV_DIR}/LD_LIBRARY_PATH`
+puts `file #{ENV_DIR}/LD_LIBRARY_PATH`
 
 # `mkdir -p #{ENV_DIR}/LD_LIBRARY_PATH`
-open(File.join(ENV_DIR,'LD_LIBRARY_PATH','value')) { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
+open(File.join(ENV_DIR,'LD_LIBRARY_PATH'), 'w') { |f| f.puts "#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH" }
 
 indent "Done!"

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ indent "Create profile.d script"
 `mkdir -p #{BUILD_DIR}/.profile.d`
 
 open("#{BUILD_DIR}/.profile.d/oracle.sh", "w") do |f|
-   f.puts "export LD_LIBRARY_PATH=#{ORACLE_INSTANT_CLIENT_DIR}:LD_LIBRARY_PATH"
+   f.puts "export LD_LIBRARY_PATH=/app/vendor/oracle_instantclient:LD_LIBRARY_PATH"
 end
 
 indent "Save LD_LIBRARY_PATH to ENV_DIR"

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # this pack is valid for apps with a .oracle.ini in the root
-if [ -f $1/.oracle.ini ]; then
+if [ -f $1/.oracle.yml ]; then
   echo "Oracle"
   exit 0
 else


### PR DESCRIPTION
I created a oracle-heroku-buildpack, this buildpack was inspired by https://github.com/nasali/oracle-oci8-heroku-buildpack but notable differences:

1. Actually works!
1. Technically should works with any version of ruby or ruby-oci8
1. Allows Bundler to compile ruby-oci8 
1. Uses Oracle Instant Client v12.1, includes: basic, sdk, and sqlplus
1. Allows the setting the tnsnames.ora and sqlnet.ora files to be used by the instant client library